### PR TITLE
[FEAT] 로그인 멤버 반환 util

### DIFF
--- a/src/main/java/com/diary/common/exception/ErrorCode.java
+++ b/src/main/java/com/diary/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
      * 400 BAD_REQUEST: 잘못된 요청
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "Invalid request."),
+    NO_LOGIN_USER(HttpStatus.BAD_REQUEST, "로그인된 유저가 없습니다."),
 
     /*
      * 401 UNAUTHORIZED: 인증되지 않은 사용자의 요청

--- a/src/main/java/com/diary/config/auth/SecurityConfig.java
+++ b/src/main/java/com/diary/config/auth/SecurityConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -28,22 +27,16 @@ public class SecurityConfig {
                 //basic 인증방식은 username:password를 base64 인코딩으로 Authroization 헤더로 보내는 방식
                 .httpBasic().disable()
                 .formLogin().disable()
-                //세션을 생성하지 않고, 요청마다 새로운 인증을 수행하도록 구성하는 옵션으로 REST API와 같은 환경에서 사용
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
                 //요청에 대한 인가 처리 설정
                 .authorizeRequests()
-                //인증되지 않은 사용자도 접근 가능하도록 허용 (로그인, 토큰발급에는 인증이 불필요)
-                .anyRequest().permitAll()
+                .antMatchers("/","/oauth2/**").permitAll() // 로그인은 누구나 가능하도록
+                .anyRequest().authenticated() // 그 외엔 모두 인증 필요
                 .and()
                 //OAuth 2.0 기반 인증을 처리하기위해 Provider와의 연동을 지원
                 .oauth2Login()
-                //인증에 성공하면 실행할 handler (redirect 시킬 목적)
-                //OAuth 2.0 Provider로부터 사용자 정보를 가져오는 엔드포인트를 지정하는 메서드
                 .userInfoEndpoint()
                 //OAuth 2.0 인증이 처리되는데 사용될 사용자 서비스를 지정하는 메서드
-                .userService(oAuthService)
-                .and();
+                .userService(oAuthService);
 
         return http.build();
     }

--- a/src/main/java/com/diary/domain/auth/OAuthLoginMemberUtil.java
+++ b/src/main/java/com/diary/domain/auth/OAuthLoginMemberUtil.java
@@ -1,0 +1,28 @@
+package com.diary.domain.auth;
+
+
+import com.diary.common.exception.ErrorCode;
+import com.diary.common.exception.RestApiException;
+import com.diary.domain.member.model.Member;
+import com.diary.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuthLoginMemberUtil {
+
+    private final MemberRepository memberRepository;
+
+    public Member getGoogleLoginMember() {
+        OAuth2AuthenticationToken authentication = (OAuth2AuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+        String email = authentication.getPrincipal().getAttributes().get("email").toString();
+
+        return memberRepository.findByEmail(email).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
+    }
+}

--- a/src/main/java/com/diary/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/diary/domain/member/repository/MemberRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member,Long>, MemberRepositoryCustom {
     Optional<Member> findByEmailAndProvider(String email, String provider);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/diary/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/diary/domain/member/service/MemberServiceImpl.java
@@ -1,11 +1,11 @@
 package com.diary.domain.member.service;
 
-import com.diary.domain.member.repository.MemberRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
-    private MemberRepository memberRepository;
+    private final JPAQueryFactory queryFactory;
 }


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #18 

## 📝 작업 내용
로그인 member를 반환하는 util를 작성했습니다. 

## 💭 사용방법
프로젝트 실행 후 [localhost:8080/oauth2/authorization/google](url) 로 접속해 로그인을 하고 사용해야합니다. 

컨트롤러에서 
private final OAuthLoginMemberUtil ~; 하고

각각 api에서 Member member = oauthLoginMemberUtil.getGoogleLoginMember();로 멤버를 가져와 사용하면 될 것 같습니다 !!



