### PR TITLE
[FEAT] file upload, delete, get API 추가

### DIFF
--- a/src/main/java/com/diary/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/diary/domain/experience/controller/ExperienceController.java
@@ -4,10 +4,7 @@ import com.diary.common.base.BaseResponse;
 import com.diary.common.exception.ErrorCode;
 import com.diary.common.exception.RestApiException;
 import com.diary.config.auth.MemberId;
-import com.diary.domain.experience.model.dto.CreateExperienceRequest;
-import com.diary.domain.experience.model.dto.CreateExperienceResponse;
-import com.diary.domain.experience.model.dto.UpdateExperienceRequest;
-import com.diary.domain.experience.model.dto.UpdateExperienceResponse;
+import com.diary.domain.experience.model.dto.*;
 import com.diary.domain.experience.service.ExperienceService;
 import com.diary.domain.member.model.Member;
 import com.diary.domain.member.repository.MemberRepository;
@@ -51,6 +48,15 @@ public class ExperienceController {
 
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
         return new BaseResponse<>(experienceService.updateExperience(loginMember, experienceId, updateExperienceRequest));
+    }
+
+    @DeleteMapping("/experiences/{experienceId}")
+    public BaseResponse<DeleteExperienceResponse> deleteExperience(
+            @MemberId Long memberId,
+            @PathVariable @Valid Long experienceId) {
+
+        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
+        return new BaseResponse<>(experienceService.deleteExperience(loginMember,experienceId));
     }
 
 }

--- a/src/main/java/com/diary/domain/experience/model/dto/DeleteExperienceResponse.java
+++ b/src/main/java/com/diary/domain/experience/model/dto/DeleteExperienceResponse.java
@@ -1,0 +1,19 @@
+package com.diary.domain.experience.model.dto;
+
+import com.diary.domain.post.model.dto.DeletePostResponse;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeleteExperienceResponse {
+    Long experienceId;
+
+    public static DeleteExperienceResponse of(Long experienceId) {
+
+        return new DeleteExperienceResponse(experienceId);
+    }
+}

--- a/src/main/java/com/diary/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/diary/domain/experience/service/ExperienceService.java
@@ -16,6 +16,8 @@ public interface ExperienceService {
     UpdateExperienceResponse updateExperience(Member loginMember, Long experienceId, UpdateExperienceRequest request) throws IOException;
 
     void deleteExperiences(Post post);
+
+    DeleteExperienceResponse deleteExperience(Member loginMember, Long experienceId);
     void softDeleteExperiences(Post post);
 
     List<GetExperienceResponse> getExperiences(Post post);

--- a/src/main/java/com/diary/domain/experience/service/ExperienceServiceImpl.java
+++ b/src/main/java/com/diary/domain/experience/service/ExperienceServiceImpl.java
@@ -86,6 +86,22 @@ public class ExperienceServiceImpl implements ExperienceService {
         return UpdateExperienceResponse.of(experienceId);
     }
 
+    public DeleteExperienceResponse deleteExperience(Member loginMember, Long experienceId) {
+        Experience experience = experienceRepository.findById(experienceId).orElseThrow(
+                () -> new RestApiException(ErrorCode.NOT_FOUND)
+        );
+
+        //login한 member와 post의 member가 다르면 error
+        if (!loginMember.equals(experience.getPost().getMember())) {
+            throw new RestApiException(ErrorCode.BAD_REQUEST);
+        }
+
+        experienceRepository.delete(experience);
+
+        return DeleteExperienceResponse.of(experienceId);
+    }
+
+
     //experience 삭제 (완전 삭재)
     @Override
     @Transactional

--- a/src/main/java/com/diary/domain/file/controller/FileController.java
+++ b/src/main/java/com/diary/domain/file/controller/FileController.java
@@ -4,6 +4,7 @@ import com.diary.common.base.BaseResponse;
 import com.diary.common.exception.ErrorCode;
 import com.diary.common.exception.RestApiException;
 import com.diary.config.auth.MemberId;
+import com.diary.domain.file.model.dto.DeleteFileResponse;
 import com.diary.domain.file.model.dto.UploadFileResponse;
 import com.diary.domain.file.service.FileService;
 import com.diary.domain.member.model.Member;
@@ -25,13 +26,23 @@ public class FileController {
     private final FileService fileService;
     private final MemberRepository memberRepository;
 
-    @PutMapping("/posts/{postId}/file")
-    public BaseResponse<UploadFileResponse> updateFile(
+
+    @PutMapping("/posts/{postId}/files")
+    public BaseResponse<UploadFileResponse> addFiles(
             @MemberId Long memberId,
             @PathVariable @Valid Long postId,
             @RequestPart(value = "file", required = false) List<MultipartFile> files) throws IOException {
 
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
-        return new BaseResponse<>(fileService.updateFiles(loginMember, postId, files));
+        return new BaseResponse<>(fileService.addFiles(loginMember, postId, files));
+    }
+
+    @DeleteMapping("/files/{fileId}")
+    public BaseResponse<DeleteFileResponse> deleteFiles(
+            @MemberId Long memberId,
+            @PathVariable @Valid Long fileId) throws IOException {
+
+        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
+        return new BaseResponse<>(fileService.deleteFile(loginMember, fileId));
     }
 }

--- a/src/main/java/com/diary/domain/file/controller/FileController.java
+++ b/src/main/java/com/diary/domain/file/controller/FileController.java
@@ -5,12 +5,15 @@ import com.diary.common.exception.ErrorCode;
 import com.diary.common.exception.RestApiException;
 import com.diary.config.auth.MemberId;
 import com.diary.domain.file.model.dto.DeleteFileResponse;
+import com.diary.domain.file.model.dto.GetFileResponse;
 import com.diary.domain.file.model.dto.UploadFileResponse;
 import com.diary.domain.file.service.FileService;
 import com.diary.domain.member.model.Member;
 import com.diary.domain.member.repository.MemberRepository;
+import com.diary.domain.post.model.Post;
 import com.diary.domain.post.model.dto.UpdatePostRequest;
 import com.diary.domain.post.model.dto.UpdatePostResponse;
+import com.diary.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,7 +28,22 @@ import java.util.List;
 public class FileController {
     private final FileService fileService;
     private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
 
+
+    @GetMapping("/posts/{postId}/files")
+    public BaseResponse<List<GetFileResponse>> getFiles(@MemberId Long memberId,
+                                                        @PathVariable @Valid Long postId) {
+
+        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND));
+
+        //login한 member와 post의 member가 다르면 error
+        if (!loginMember.equals(post.getMember())) {
+            throw new RestApiException(ErrorCode.BAD_REQUEST);
+        }
+        return new BaseResponse<>(fileService.getFiles(post));
+    }
 
     @PutMapping("/posts/{postId}/files")
     public BaseResponse<UploadFileResponse> addFiles(

--- a/src/main/java/com/diary/domain/file/model/dto/DeleteFileResponse.java
+++ b/src/main/java/com/diary/domain/file/model/dto/DeleteFileResponse.java
@@ -1,0 +1,19 @@
+package com.diary.domain.file.model.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DeleteFileResponse {
+
+    Long fileId;
+
+
+    public static DeleteFileResponse of(Long fileId) {
+        return new DeleteFileResponse(fileId);
+    }
+}

--- a/src/main/java/com/diary/domain/file/model/dto/GetFileResponse.java
+++ b/src/main/java/com/diary/domain/file/model/dto/GetFileResponse.java
@@ -7,10 +7,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetFileResponse {
+    private Long fileId;
     private String fileName;
     private String filePath;
 
-    public static GetFileResponse of(String fileName, String filePath) {
-        return new GetFileResponse(fileName,filePath);
+    public static GetFileResponse of(Long fileId,String fileName, String filePath) {
+        return new GetFileResponse(fileId,fileName,filePath);
     }
 }

--- a/src/main/java/com/diary/domain/file/service/FileService.java
+++ b/src/main/java/com/diary/domain/file/service/FileService.java
@@ -1,5 +1,6 @@
 package com.diary.domain.file.service;
 
+import com.diary.domain.file.model.dto.DeleteFileResponse;
 import com.diary.domain.file.model.dto.GetFileResponse;
 import com.diary.domain.file.model.dto.UploadFileResponse;
 import com.diary.domain.member.model.Member;
@@ -12,11 +13,9 @@ import java.util.Map;
 
 public interface FileService {
     UploadFileResponse uploadFiles(Long postId, List<MultipartFile> files) throws IOException;
-
-    void deleteFiles(Post post);
-
-    UploadFileResponse updateFiles(Member loginMember,Long postId, List<MultipartFile> files) throws IOException;
+    UploadFileResponse addFiles(Member loginMember, Long postId, List<MultipartFile> files) throws IOException;
     List<GetFileResponse> getFiles(Post post);
+    DeleteFileResponse deleteFile(Member loginMember, Long fileId);
     void softDeleteFiles(Post post);
 
 

--- a/src/main/java/com/diary/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/com/diary/domain/file/service/FileServiceImpl.java
@@ -143,7 +143,7 @@ public class FileServiceImpl implements FileService {
         if (!CollectionUtils.isEmpty(files)) {
             for (File file : files) {
                 getFileResponses.add(
-                        GetFileResponse.of(file.getOrigFileName(), file.getFilePath())
+                        GetFileResponse.of(file.getId(),file.getOrigFileName(), file.getFilePath())
                 );
             }
         }


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #56 

## 📝 작업 내용
파일 upload, delete, get api를 추가하였습니다.
## 💭 주의 사항

## 💡 실행 결과
*Get http://localhost:8080/api/v1/posts/1/files
```
{
    "timestamp": "2023-07-16T21:08:33.3084292",
    "message": "요청에 성공하였습니다.",
    "result": [
        {
            "fileId": 1,
            "fileName": "스크린샷 2023-03-18 004044.png",
            "filePath": "https://portfolio-diary.s3.ap-northeast-2.amazonaws.com/files/63de98a3-fe4b-48cd-be3b-cf7ebcb56cbf.png"
        }
    ]
}
```
*  Put http://localhost:8080/api/v1/posts/1/files
```
{
    "timestamp": "2023-07-16T20:55:39.195387",
    "message": "요청에 성공하였습니다.",
    "result": {
        "files": [
            2
        ]
    }
}
```
* Delete http://localhost:8080/api/v1/files/2
```
{
    "timestamp": "2023-07-16T20:56:20.9300262",
    "message": "요청에 성공하였습니다.",
    "result": {
        "fileId": 2
    }
}
```