### PR TITLE
[FEAT] 마이페이지에서 필요한 유저 정보 조회 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,4 @@ out/
 src/main/resources/*.yml
 src/main/resources/*.properties
 docker/.env
-src/main/frontend
+src/main/frontend/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 src/main/resources/*.yml
 src/main/resources/*.properties
 docker/.env
+src/main/frontend

--- a/src/main/java/com/diary/domain/member/controller/MemberController.java
+++ b/src/main/java/com/diary/domain/member/controller/MemberController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
 
-    @GetMapping("/mypage")
+    @GetMapping("/mypages")
     public BaseResponse<FindMyPageUserResponse> findMyPageUser(@MemberId Long memberId){
         return new BaseResponse<>(memberService.findMyPageUser(memberId));
     }

--- a/src/main/java/com/diary/domain/member/controller/MemberController.java
+++ b/src/main/java/com/diary/domain/member/controller/MemberController.java
@@ -1,11 +1,26 @@
 package com.diary.domain.member.controller;
 
+import com.diary.common.base.BaseResponse;
+import com.diary.common.exception.ErrorCode;
+import com.diary.common.exception.RestApiException;
+import com.diary.config.auth.MemberId;
+import com.diary.domain.member.model.Member;
+import com.diary.domain.member.model.dto.FindMyPageUserResponse;
 import com.diary.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @RestController
 public class MemberController {
     private final MemberService memberService;
+
+    @GetMapping("/mypage")
+    public BaseResponse<FindMyPageUserResponse> findMyPageUser(@MemberId Long memberId){
+        return new BaseResponse<>(memberService.findMyPageUser(memberId));
+    }
+
 }

--- a/src/main/java/com/diary/domain/member/model/dto/FindMyPageUserResponse.java
+++ b/src/main/java/com/diary/domain/member/model/dto/FindMyPageUserResponse.java
@@ -1,0 +1,13 @@
+package com.diary.domain.member.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FindMyPageUserResponse {
+    private String name;
+    private Long sinceDate;
+}

--- a/src/main/java/com/diary/domain/member/service/MemberService.java
+++ b/src/main/java/com/diary/domain/member/service/MemberService.java
@@ -1,4 +1,7 @@
 package com.diary.domain.member.service;
 
+import com.diary.domain.member.model.dto.FindMyPageUserResponse;
+
 public interface MemberService {
+    FindMyPageUserResponse findMyPageUser(Long memberId);
 }

--- a/src/main/java/com/diary/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/diary/domain/member/service/MemberServiceImpl.java
@@ -20,7 +20,7 @@ public class MemberServiceImpl implements MemberService {
     public FindMyPageUserResponse findMyPageUser(Long memberId) {
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
         String nickname = loginMember.getNickname();
-        Long daysSinceSignUp = ChronoUnit.DAYS.between(loginMember.getCreatedAt().toLocalDate(), LocalDate.now());
+        Long daysSinceSignUp = ChronoUnit.DAYS.between(loginMember.getCreatedAt().toLocalDate(), LocalDate.now()) + 1L;
 
         return new FindMyPageUserResponse(nickname, daysSinceSignUp);
     }

--- a/src/main/java/com/diary/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/diary/domain/member/service/MemberServiceImpl.java
@@ -1,11 +1,27 @@
 package com.diary.domain.member.service;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.diary.common.exception.ErrorCode;
+import com.diary.common.exception.RestApiException;
+import com.diary.domain.member.model.Member;
+import com.diary.domain.member.model.dto.FindMyPageUserResponse;
+import com.diary.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
-    private final JPAQueryFactory queryFactory;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public FindMyPageUserResponse findMyPageUser(Long memberId) {
+        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
+        String nickname = loginMember.getNickname();
+        Long daysSinceSignUp = ChronoUnit.DAYS.between(loginMember.getCreatedAt().toLocalDate(), LocalDate.now());
+
+        return new FindMyPageUserResponse(nickname, daysSinceSignUp);
+    }
 }


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #53 

## 📝 작업 내용
마이페이지에서 필요한 유저 정보 조회하는 API를 작성했습니다.
- 닉네임
- 가입한 지 며칠째인지

## 💭 주의 사항

## 💡 리뷰 포인트
