### PR TITLE
[FEAT] 휴지통 페이지 API

### DIFF
--- a/src/main/java/com/diary/common/base/BaseEntity.java
+++ b/src/main/java/com/diary/common/base/BaseEntity.java
@@ -38,10 +38,8 @@ public class BaseEntity {
      * @param status
      */
     public void changeStatus(BaseStatus status) {
-        if (status.equals(BaseStatus.ACTIVE))
-            this.status = BaseStatus.INACTIVE;
-        else
-            this.status=BaseStatus.ACTIVE;
+        updateUpdatedAt(LocalDateTime.now());
+        this.status = (status == BaseStatus.ACTIVE) ? BaseStatus.INACTIVE : BaseStatus.ACTIVE;
     }
 
 }

--- a/src/main/java/com/diary/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/diary/domain/experience/service/ExperienceService.java
@@ -23,4 +23,6 @@ public interface ExperienceService {
     List<GetExperienceResponse> getExperiences(Post post);
 
     void hardDeleteExperiences(Post post);
+
+    void updateExperienceActive(Post post);
 }

--- a/src/main/java/com/diary/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/diary/domain/experience/service/ExperienceService.java
@@ -21,4 +21,6 @@ public interface ExperienceService {
     void softDeleteExperiences(Post post);
 
     List<GetExperienceResponse> getExperiences(Post post);
+
+    void hardDeleteExperiences(Post post);
 }

--- a/src/main/java/com/diary/domain/experience/service/ExperienceServiceImpl.java
+++ b/src/main/java/com/diary/domain/experience/service/ExperienceServiceImpl.java
@@ -145,5 +145,13 @@ public class ExperienceServiceImpl implements ExperienceService {
         }
     }
 
+    @Override
+    public void updateExperienceActive(Post post) {
+        List<Experience> experiences = experienceRepository.findAllByPost(post);
+        if (experiences != null) {
+            experiences.forEach(experience -> experience.changeStatus(experience.getStatus()));
+        }
+    }
+
 
 }

--- a/src/main/java/com/diary/domain/experience/service/ExperienceServiceImpl.java
+++ b/src/main/java/com/diary/domain/experience/service/ExperienceServiceImpl.java
@@ -14,10 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -138,6 +135,14 @@ public class ExperienceServiceImpl implements ExperienceService {
             }
         }
         return responses;
+    }
+
+    @Override
+    public void hardDeleteExperiences(Post post) {
+        List<Experience> experiences = experienceRepository.findAllByPost(post);
+        if (experiences != null) {
+            experiences.forEach(experience -> experienceRepository.delete(experience));
+        }
     }
 
 

--- a/src/main/java/com/diary/domain/file/service/FileService.java
+++ b/src/main/java/com/diary/domain/file/service/FileService.java
@@ -18,4 +18,5 @@ public interface FileService {
     void softDeleteFiles(Post post);
     void hardDeleteFiles(Post post);
 
+    void updateFileActive(Post post);
 }

--- a/src/main/java/com/diary/domain/file/service/FileService.java
+++ b/src/main/java/com/diary/domain/file/service/FileService.java
@@ -9,7 +9,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 public interface FileService {
     UploadFileResponse uploadFiles(Long postId, List<MultipartFile> files) throws IOException;
@@ -17,6 +16,6 @@ public interface FileService {
     List<GetFileResponse> getFiles(Post post);
     DeleteFileResponse deleteFile(Member loginMember, Long fileId);
     void softDeleteFiles(Post post);
+    void hardDeleteFiles(Post post);
 
-
-    }
+}

--- a/src/main/java/com/diary/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/com/diary/domain/file/service/FileServiceImpl.java
@@ -116,6 +116,19 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
+    public void hardDeleteFiles(Post post) {
+        List<File> files = fileRepository.findAllByPost(post);
+        if(!CollectionUtils.isEmpty(files)){
+            files.forEach(
+                    file -> {
+                    amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, file.getFilePath().substring(56)));
+                    fileRepository.delete(file);
+                    }
+            );
+        }
+    }
+
+    @Override
     @Transactional
     //파일 추가
     public UploadFileResponse addFiles(Member loginMember, Long postId, List<MultipartFile> files) throws IOException {

--- a/src/main/java/com/diary/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/com/diary/domain/file/service/FileServiceImpl.java
@@ -129,6 +129,14 @@ public class FileServiceImpl implements FileService {
     }
 
     @Override
+    public void updateFileActive(Post post) {
+        List<File> files = fileRepository.findAllByPost(post);
+        if(!CollectionUtils.isEmpty(files)) {
+            files.forEach(file -> {file.changeStatus(file.getStatus());});
+        }
+    }
+
+    @Override
     @Transactional
     //파일 추가
     public UploadFileResponse addFiles(Member loginMember, Long postId, List<MultipartFile> files) throws IOException {

--- a/src/main/java/com/diary/domain/post/controller/PostController.java
+++ b/src/main/java/com/diary/domain/post/controller/PostController.java
@@ -102,4 +102,11 @@ public class PostController {
         return new BaseResponse<>("완전히 삭제되었습니다.");
     }
 
+    @PostMapping("active/posts/{postId}")
+    public BaseResponse<String> updatePostActive(@MemberId Long memberId, @PathVariable @Valid Long postId){
+        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
+        postService.updatePostActive(loginMember, postId);
+        return new BaseResponse<>("복원 되었습니다.");
+    }
+
 }

--- a/src/main/java/com/diary/domain/post/controller/PostController.java
+++ b/src/main/java/com/diary/domain/post/controller/PostController.java
@@ -77,7 +77,7 @@ public class PostController {
     @GetMapping("in-active/posts")
     public BaseResponse<GetPagePostsResponse> getAllRemovePosts(
             @MemberId Long memberId,
-            @PageableDefault(size = 10, sort = "updateAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
         return new BaseResponse<>(postService.getAllRemovePostsWithPaging(loginMember, pageable));

--- a/src/main/java/com/diary/domain/post/controller/PostController.java
+++ b/src/main/java/com/diary/domain/post/controller/PostController.java
@@ -77,7 +77,7 @@ public class PostController {
     @GetMapping("in-active/posts")
     public BaseResponse<GetPagePostsResponse> getAllRemovePosts(
             @MemberId Long memberId,
-            @PageableDefault(size = 10, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+            @PageableDefault(sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
         return new BaseResponse<>(postService.getAllRemovePostsWithPaging(loginMember, pageable));

--- a/src/main/java/com/diary/domain/post/controller/PostController.java
+++ b/src/main/java/com/diary/domain/post/controller/PostController.java
@@ -73,6 +73,16 @@ public class PostController {
         return new BaseResponse<>(postService.getAllPostsWithPaging(loginMember, orderType, pageable));
     }
 
+    //삭제된 Post 목록 조회 with Paging
+    @GetMapping("in-active/posts")
+    public BaseResponse<GetPagePostsResponse> getAllRemovePosts(
+            @MemberId Long memberId,
+            @PageableDefault(size = 10, sort = "updateAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
+        return new BaseResponse<>(postService.getAllRemovePostsWithPaging(loginMember, pageable));
+    }
+
     //Post tag별 목록 조회
     @GetMapping("/posts/tag")
     public BaseResponse<GetPagePostsResponse> findPostsByTagNames(

--- a/src/main/java/com/diary/domain/post/controller/PostController.java
+++ b/src/main/java/com/diary/domain/post/controller/PostController.java
@@ -95,14 +95,14 @@ public class PostController {
         return new BaseResponse<>(postService.findPostsByTagNames(loginMember, tagNames, orderType, pageable));
     }
 
-    @DeleteMapping("remove/posts/{postId}")
+    @DeleteMapping("/posts/{postId}/delete")
     public BaseResponse<String> hardDeletePost(@MemberId Long memberId, @PathVariable @Valid Long postId) {
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
         postService.hardDeletePost(loginMember, postId);
         return new BaseResponse<>("완전히 삭제되었습니다.");
     }
 
-    @PostMapping("active/posts/{postId}")
+    @PostMapping("/posts/{postId}/restore")
     public BaseResponse<String> updatePostActive(@MemberId Long memberId, @PathVariable @Valid Long postId){
         Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
         postService.updatePostActive(loginMember, postId);

--- a/src/main/java/com/diary/domain/post/controller/PostController.java
+++ b/src/main/java/com/diary/domain/post/controller/PostController.java
@@ -95,4 +95,11 @@ public class PostController {
         return new BaseResponse<>(postService.findPostsByTagNames(loginMember, tagNames, orderType, pageable));
     }
 
+    @DeleteMapping("remove/posts/{postId}")
+    public BaseResponse<String> hardDeletePost(@MemberId Long memberId, @PathVariable @Valid Long postId) {
+        Member loginMember = memberRepository.findById(memberId).orElseThrow(() -> new RestApiException(ErrorCode.NO_LOGIN_USER));
+        postService.hardDeletePost(loginMember, postId);
+        return new BaseResponse<>("완전히 삭제되었습니다.");
+    }
+
 }

--- a/src/main/java/com/diary/domain/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/diary/domain/post/repository/PostRepositoryCustom.java
@@ -10,5 +10,7 @@ import java.util.List;
 
 public interface PostRepositoryCustom {
     Page<Post> findAllWithPaging(Long memberId, String orderType, Pageable pageable);
+    Page<Post> findInActiveAllWithPaging(Long memberId, Pageable pageable);
+
     Page<GetPostsResponse> findPostsByTagNames(Member loginMember, List<String> tagNames, String orderType, Pageable pageable);
 }

--- a/src/main/java/com/diary/domain/post/repository/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/diary/domain/post/repository/PostRepositoryCustomImpl.java
@@ -6,7 +6,6 @@ import com.diary.domain.post.model.Post;
 import com.diary.domain.post.model.dto.GetPostsResponse;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.SubQueryExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +50,31 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
                 .from(post).
                 where(post.member.id.eq(memberId),
                         post.status.eq(BaseStatus.ACTIVE))
+                .fetchFirst();
+
+        return new PageImpl<>(result, pageable, total);
+    }
+
+    @Override
+    public Page<Post> findInActiveAllWithPaging(Long memberId, Pageable pageable) {
+        List<Post> result = queryFactory
+                .selectFrom(post)
+                .where(
+                        post.member.id.eq(memberId)
+                        .and(post.status.eq(BaseStatus.INACTIVE)
+                        ))
+                .orderBy(post.updatedAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(post.id.count())
+                .from(post).
+                where(
+                        post.member.id.eq(memberId)
+                        .and(post.status.eq(BaseStatus.INACTIVE))
+                )
                 .fetchFirst();
 
         return new PageImpl<>(result, pageable, total);

--- a/src/main/java/com/diary/domain/post/service/PostService.java
+++ b/src/main/java/com/diary/domain/post/service/PostService.java
@@ -22,4 +22,6 @@ public interface PostService {
 
 
     GetPagePostsResponse findPostsByTagNames(Member loginMember, List<String> tagNames, String orderType, Pageable pageable);
+
+    void hardDeletePost(Member loginMember, Long postId);
 }

--- a/src/main/java/com/diary/domain/post/service/PostService.java
+++ b/src/main/java/com/diary/domain/post/service/PostService.java
@@ -24,4 +24,6 @@ public interface PostService {
     GetPagePostsResponse findPostsByTagNames(Member loginMember, List<String> tagNames, String orderType, Pageable pageable);
 
     void hardDeletePost(Member loginMember, Long postId);
+
+    void updatePostActive(Member member, Long postId);
 }

--- a/src/main/java/com/diary/domain/post/service/PostService.java
+++ b/src/main/java/com/diary/domain/post/service/PostService.java
@@ -18,6 +18,8 @@ public interface PostService {
     GetPostResponse getPost(Member loginMember, Long postId);
 
     GetPagePostsResponse getAllPostsWithPaging(Member loginMember, String orderType, Pageable pageable);
+    GetPagePostsResponse getAllRemovePostsWithPaging(Member loginMember, Pageable pageable);
+
 
     GetPagePostsResponse findPostsByTagNames(Member loginMember, List<String> tagNames, String orderType, Pageable pageable);
 }

--- a/src/main/java/com/diary/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/diary/domain/post/service/PostServiceImpl.java
@@ -188,4 +188,16 @@ public class PostServiceImpl implements PostService {
             postRepository.delete(post);
         }
     }
+
+    @Override
+    public void updatePostActive(Member member, Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND));
+        if(member.equals(post.getMember())){
+            post.changeStatus(post.getStatus());
+            tagService.updateTagActive(post);
+            fileService.updateFileActive(post);
+            experienceService.updateExperienceActive(post);
+        }
+
+    }
 }

--- a/src/main/java/com/diary/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/diary/domain/post/service/PostServiceImpl.java
@@ -176,4 +176,16 @@ public class PostServiceImpl implements PostService {
 
         return GetPagePostsResponse.of(pagePosts, totalPages,totalPosts);
     }
+
+    @Override
+    public void hardDeletePost(Member loginMember, Long postId) {
+        //postId로 post 조회
+        Post post = postRepository.findById(postId).orElseThrow(() -> new RestApiException(ErrorCode.NOT_FOUND));
+        if (loginMember.equals(post.getMember())) {
+            experienceService.hardDeleteExperiences(post);
+            tagService.hardDeleteTags(post);
+            fileService.hardDeleteFiles(post);
+            postRepository.delete(post);
+        }
+    }
 }

--- a/src/main/java/com/diary/domain/post/service/PostServiceImpl.java
+++ b/src/main/java/com/diary/domain/post/service/PostServiceImpl.java
@@ -127,26 +127,38 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional
     public GetPagePostsResponse getAllPostsWithPaging(Member loginMember, String orderType, Pageable pageable) {
-
         Page<Post> list = postRepository.findAllWithPaging(loginMember.getId(), orderType, pageable);
+        return toPagePostsResponse(loginMember, list);
 
-        int totalPages = list.getTotalPages();
-        int totalPosts = (int) list.getTotalElements(); //long형을 int형으로 받음
+    }
+
+    //삭제된 모든 Post 페이징 조회
+    @Override
+    @Transactional
+    public GetPagePostsResponse getAllRemovePostsWithPaging(Member loginMember, Pageable pageable) {
+        Page<Post> posts = postRepository.findInActiveAllWithPaging(loginMember.getId(), pageable);
+        return toPagePostsResponse(loginMember, posts);
+
+    }
+
+    // Post -> GetPagePostsResponse로 변환
+    public GetPagePostsResponse toPagePostsResponse(Member member, Page<Post> posts){
+        int totalPages = posts.getTotalPages();
+        int totalPosts = (int) posts.getTotalElements(); //long형을 int형으로 받음
 
         //받아온 Page<Post> list를 GetPostsResponse dto 형식으로 변환하여 list에 저장
-        List<GetPostsResponse> pagePosts = list.map(
+        List<GetPostsResponse> pagePosts = posts.map(
                 post -> GetPostsResponse.of(
                         post.getId(),
                         post.getTitle(),
                         post.getBeginAt(),
                         post.getFinishAt(),
-                        tagService.findTagName(loginMember, post.getId())
+                        tagService.findTagName(member, post.getId())
                 )
         ).getContent();
 
         //totalPage, totalPosts 를 포함하여 GetPagePostsResponse 로 반환
         return GetPagePostsResponse.of(pagePosts, totalPages, totalPosts);
-
     }
 
     @Override

--- a/src/main/java/com/diary/domain/tag/service/TagService.java
+++ b/src/main/java/com/diary/domain/tag/service/TagService.java
@@ -8,7 +8,6 @@ import com.diary.domain.tag.model.dto.FindTagResponse;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 public interface TagService {
     CreateTagResponse createTag(Long postId, List<CreateTagRequest> tags, Member member) throws IOException;
@@ -18,4 +17,6 @@ public interface TagService {
     List<FindTagResponse> getTags(Post post);
     List<FindTagResponse> findTagList(Long memberId);
     List<String> findTagName(Member member, Long postId);
+
+    void hardDeleteTags(Post post);
 }

--- a/src/main/java/com/diary/domain/tag/service/TagService.java
+++ b/src/main/java/com/diary/domain/tag/service/TagService.java
@@ -19,4 +19,6 @@ public interface TagService {
     List<String> findTagName(Member member, Long postId);
 
     void hardDeleteTags(Post post);
+
+    void updateTagActive(Post post);
 }

--- a/src/main/java/com/diary/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/diary/domain/tag/service/TagServiceImpl.java
@@ -134,4 +134,12 @@ public class TagServiceImpl implements TagService {
         return tagRepository.findTagNameByMemberAndPost(member, postId);
     }
 
+    @Override
+    public void hardDeleteTags(Post post) {
+        List<Tag> tags = tagRepository.findAllByPost(post);
+        if (!CollectionUtils.isEmpty(tags)) {
+            tags.forEach(tag -> tagRepository.delete(tag));
+        }
+    }
+
 }

--- a/src/main/java/com/diary/domain/tag/service/TagServiceImpl.java
+++ b/src/main/java/com/diary/domain/tag/service/TagServiceImpl.java
@@ -142,4 +142,12 @@ public class TagServiceImpl implements TagService {
         }
     }
 
+    @Override
+    public void updateTagActive(Post post) {
+        List<Tag> tags = tagRepository.findAllByPost(post);
+        if (!CollectionUtils.isEmpty(tags)) {
+            tags.forEach(tag -> tag.changeStatus(tag.getStatus()));
+        }
+    }
+
 }


### PR DESCRIPTION
## ❗️ 이슈 번호
Closes #59 

## 📝 작업 내용
- 휴지통에서 조회할 post를 반환하는 api를 구현했습니다.
- 휴지통 삭제 -> hard delete 하는 api를 구현했습니다.
- 휴지통 복원 -> status를 active로 변환시켜 복원하도록 하는 api를 구현했습니다. 

## 💭 주의 사항
GetPagePostsResponse로 변환하는 코드가 중복되어 함수로 처리했습니다. 

## 💡 리뷰 포인트
